### PR TITLE
Allow for blank lines within filter blocks

### DIFF
--- a/syntaxes/haml.json
+++ b/syntaxes/haml.json
@@ -30,7 +30,7 @@
     },
     {
       "begin": "^(\\s*):ruby$",
-      "end": "^\\1$",
+      "end": "^(?=\\1[^\\s]+)",
       "name": "source.ruby.embedded.filter.haml",
       "patterns": [
         {
@@ -59,7 +59,7 @@
     },
     {
       "begin": "^(\\s*):javascript$",
-      "end": "^\\1$",
+      "end": "^(?=\\1[^\\s]+)",
       "name": "source.embedded.filter.js",
       "patterns": [
         {
@@ -69,7 +69,7 @@
     },
     {
       "begin": "^(\\s*):ruby$",
-      "end": "^\\1$",
+      "end": "^(?=\\1[^\\s]+)",
       "name": "source.ruby.embedded.filter.haml",
       "patterns": [
         {
@@ -226,7 +226,7 @@
     },
     {
       "begin": "^(\\s*):(ruby|opal)$",
-      "end": "^\\1$",
+      "end": "^(?=\\1[^\\s]+)",
       "name": "source.ruby.embedded.filter.haml",
       "patterns": [
         {
@@ -236,7 +236,7 @@
     },
     {
       "begin": "^(\\s*):ruby$",
-      "end": "^\\1([^\\s]*)$",
+      "end": "^(?=\\1[^\\s]+))",
       "name": "source.ruby.embedded.filter.haml",
       "patterns": [
         {
@@ -246,7 +246,7 @@
     },
     {
       "begin": "^(\\s*):(style|sass)$",
-      "end": "^\\1$",
+      "end": "^(?=\\1[^\\s]+)",
       "name": "source.sass.embedded.filter.haml",
       "patterns": [
         {
@@ -256,7 +256,7 @@
     },
     {
       "begin": "^(\\s*):(java)?script$",
-      "end": "^\\1([^\\s]*)$",
+      "end": "^(?=\\1[^\\s]+)",
       "name": "source.js.embedded.filter.haml",
       "patterns": [
         {
@@ -266,7 +266,7 @@
     },
     {
       "begin": "^(\\s*):coffee(script)?$",
-      "end": "^\\1([^\\s]*)$",
+      "end": "^(?=\\1[^\\s]+)",
       "name": "source.coffee.embedded.filter.haml",
       "patterns": [
         {
@@ -276,7 +276,7 @@
     },
     {
       "begin": "^(\\s*):plain$",
-      "end": "^\\1([^\\s]*)$",
+      "end": "^(?=\\1[^\\s]+)",
       "name": "text.plain.embedded.filter.haml",
       "patterns": [
         {
@@ -291,7 +291,7 @@
           "name": "keyword.control.filter.haml"
         }
       },
-      "end": "^(?!\\1  )",
+      "end": "(?m:(?<=\\n)(?!\\1  |\\n))",
       "name": "source.ruby.embedded.filter.haml",
       "patterns": [
         {
@@ -331,7 +331,7 @@
     },
     {
       "begin": "^(\\s*):(styles|sass)$",
-      "end": "^\\1$",
+      "end": "^(?=\\1[^\\s]+)",
       "name": "source.sass.embedded.filter.haml",
       "patterns": [
         {
@@ -341,7 +341,7 @@
     },
     {
       "begin": "^(\\s*):(java)?script$",
-      "end": "^\\1$",
+      "end": "^(?=\\1[^\\s]+)",
       "name": "source.js.embedded.filter.haml",
       "patterns": [
         {
@@ -351,7 +351,7 @@
     },
     {
       "begin": "^(\\s*):plain$",
-      "end": "^\\1$",
+      "end": "^(?=\\1[^\\s]+)",
       "name": "text.plain.embedded.filter.haml",
       "patterns": [
         {


### PR DESCRIPTION
Attempts to resolve #3.

I'm OK with Regular Expressions but not familiar with Oniguruma syntax or with Textmate-style syntax files, so I have no idea if what I'm doing here is correct.

My first stab just changed the matched line to `^\1[^\s]+$`, to say it indents as far as the beginning of the filter block (`^(\s*):ruby` e.g.) but no farther _and has something other than spaces on it_ – that is, it's not just a blank line. But what was happening was that the `%div` in the example at #3 was ending up white, because it matched that line.

So instead I'm using a lookahead, which just matches the start of a new line but not any of the text on that line.

It does the trick for my use case, but I honestly have no idea if it's a reliable overall solution. Definitely open to suggestions etc.