### PR TITLE
Fix multiline example in scripts.haml

### DIFF
--- a/tests/templates/scripts.haml
+++ b/tests/templates/scripts.haml
@@ -15,15 +15,15 @@
   }}
 "not js"
 :ruby
-  - puts "Hello world"
-  - (1..5).each do |x|
-  -   puts x
-  - end
+  puts "Hello world"
+  (1..5).each do |x|
+    puts x
+  end
 :opal
-  - puts "Hello world"
-  - (1..5).each do |x|
-  -   puts x
-  - end
+  puts "Hello world"
+  (1..5).each do |x|
+    puts x
+  end
 :coffee
   # Assignment:
   number   = 42


### PR DESCRIPTION
Multi-line script blocks in Haml, such as `:ruby`, enable having multiple lines of embedded Ruby code without prepending each line with `- `. This use case is now correctly reflected in the scripts.haml test case.

This also exposes the bug with multi-line syntax highlighting (#12), which will be fixed in a follow-up.