### PR TITLE
Fix highlighting for multiline Ruby script blocks

### DIFF
--- a/syntaxes/haml.json
+++ b/syntaxes/haml.json
@@ -20,7 +20,7 @@
     },
     {
       "begin": "^(\\s*):ruby",
-      "end": "^(?=\\1\\s+|$\\n*)",
+      "end": "^(?!\\1\\s+|$\\n*)",
       "name": "source.ruby.embedded.filter.haml",
       "patterns": [
         {
@@ -49,7 +49,7 @@
     },
     {
       "begin": "^(\\s*):ruby$",
-      "end": "^(?=\\1\\s+|$\\n*)",
+      "end": "^(?!\\1\\s+|$\\n*)",
       "name": "source.ruby.embedded.filter.haml",
       "patterns": [
         {
@@ -206,7 +206,7 @@
     },
     {
       "begin": "^(\\s*):(ruby|opal)$",
-      "end": "^(?=\\1\\s+|$\\n*)",
+      "end": "^(?!\\1\\s+|$\\n*)",
       "name": "source.ruby.embedded.filter.haml",
       "patterns": [
         {
@@ -216,7 +216,7 @@
     },
     {
       "begin": "^(\\s*):ruby$",
-      "end": "^(?=\\1\\s+|$\\n*))",
+      "end": "^(?!\\1\\s+|$\\n*)",
       "name": "source.ruby.embedded.filter.haml",
       "patterns": [
         {


### PR DESCRIPTION
Fixes #12

By switching the `end` parameter for `:ruby` blocks to be the same as the `end` parameter for `:javascript` blocks, proper multiline syntax highlighting is restored.


```diff
-      "end": "^(?=\\1\\s+|$\\n*)",
+      "end": "^(?!\\1\\s+|$\\n*)",
```

Before:

<img width="256" alt="Screenshot 2019-05-20 18 58 34" src="https://user-images.githubusercontent.com/1441807/58057193-08ef6a00-7b32-11e9-8452-6e15fec81699.png">

After:

<img width="263" alt="Screenshot 2019-05-20 18 57 14" src="https://user-images.githubusercontent.com/1441807/58057192-068d1000-7b32-11e9-8663-e97e6c0df0bb.png">
