### PR TITLE
Support tailwind class names

### DIFF
--- a/syntaxes/haml.json
+++ b/syntaxes/haml.json
@@ -113,7 +113,7 @@
               "name": "entity.other.attribute-name.class"
             }
           },
-          "match": "(\\.[\\w-]+)",
+          "match": "(\\.[\\w\\-\\:]+)",
           "name": "meta.selector.css"
         },
         {


### PR DESCRIPTION
Because the ":" character is not included in the regex some of the classes in tailwindcss is not properly colorized.

This is from before the fix:
![Screenshot 2020-09-14 at 12 08 49](https://user-images.githubusercontent.com/321551/93073712-a48bde80-f683-11ea-8dda-ccab56cded5f.png)

This is after the fix:
![Screenshot 2020-09-14 at 12 09 42](https://user-images.githubusercontent.com/321551/93073770-b5d4eb00-f683-11ea-8cf2-a1f52db5105f.png)

