### PR TITLE
Inline script

### DIFF
--- a/syntaxes/haml.json
+++ b/syntaxes/haml.json
@@ -48,6 +48,16 @@
       ]
     },
     {
+      "begin": "^(\\s*)%script",
+      "end": "^(?!\\1\\s+|$\\n*)",
+      "name": "js.inline.haml",
+      "patterns": [
+        {
+          "include": "source.js"
+        }
+      ]
+    },
+    {
       "begin": "^(\\s*):ruby$",
       "end": "^(?!\\1\\s+|$\\n*)",
       "name": "source.ruby.embedded.filter.haml",

--- a/tests/templates/scripts.haml
+++ b/tests/templates/scripts.haml
@@ -14,6 +14,20 @@
     es6Baby();
   }}
 "not js"
+
+%script
+  console.log('Hello world')
+
+  1 + 2 = 100
+
+  console.log("ok")
+
+  if (false) {
+    doSomething();
+  } else {() => {
+    es6Baby();
+  }}
+"not js"
 :ruby
   puts "Hello world"
   (1..5).each do |x|


### PR DESCRIPTION
Adds syntax highlighting for `%script` inline tags, pretty much just reused the `:javascript` tag for it.

Before:
![image](https://user-images.githubusercontent.com/8260015/174919519-2f078a5b-39ff-4469-b7d0-9d305db7afc0.png)

After:
![image](https://user-images.githubusercontent.com/8260015/174918740-badc3162-0cf7-4359-b13e-479a32462397.png)
